### PR TITLE
Updates to support "spoof" now available in gmetric4j.

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,13 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="src" output="target/classes" path="src/main/java"/>
-	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources"/>
-	<classpathentry kind="src" output="target/test-classes" path="src/test/java"/>
-	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5"/>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.maven.ide.eclipse.MAVEN2_CLASSPATH_CONTAINER"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/gmetric4j"/>
 	<classpathentry kind="lib" path="/gmetric4j/lib/junit-4.1.jar"/>
 	<classpathentry kind="lib" path="/gmetric4j/lib/oncrpc-1.0.7.jar"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/J2SE-1.5">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+/.settings

--- a/.project
+++ b/.project
@@ -15,8 +15,14 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.maven.ide.eclipse.maven2Nature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>

--- a/README
+++ b/README
@@ -2,7 +2,7 @@ Name
     jmxetric - jvm instrumentation to ganglia
 
 Version
-    jmxetric 1.0.3
+    jmxetric 1.0.4-SNAPSHOT
 
     The latest version of this software and document will always be found at 
     https://github.com/ganglia/jmxetric
@@ -50,6 +50,9 @@ Configuration
 	mode          The UDP addressing mode, either multicast or unicast (default multicast)
 	
 	wireformat31x True if the ganglia v3.1.x wire format should be used (default false)
+	
+	spoof         An IP:hostname pair that will be used to spoof the metric host information.
+	              (default: no spoofing, i.e., local hostname reported by OS)
 
     process       A name that is prefixed to the metric name before publication 
                   (so that metrics from different JVMs on the same host can be 
@@ -100,6 +103,7 @@ Configuration
           <!ATTLIST ganglia port CDATA #REQUIRED>
           <!ATTLIST ganglia mode CDATA #REQUIRED>
           <!ATTLIST ganglia wireformat31x CDATA #REQUIRED>
+          <!ATTLIST ganglia spoof CDATA #IMPLIED>
        <!ELEMENT jvm EMPTY>
           <!ATTLIST jvm process CDATA "">
     ]>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <artifactId>jmxetric</artifactId>
   <name>JMXetric</name>
   <packaging>jar</packaging>
-  <version>1.0.3</version>
+  <version>1.0.4-SNAPSHOT</version>
   <description>JVM instrumentation to Ganglia</description>
   <url>http://github.com/ganglia/jmxetric</url>
   <licenses>
@@ -32,17 +32,21 @@
       <email>daniel@pocock.com.au</email>
     </developer>
   </developers>
+  <properties>
+    <gmetric4j.version>1.0.3-SNAPSHOT</gmetric4j.version>
+    <oncrpc.version>1.0.7</oncrpc.version>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>info.ganglia.gmetric4j</groupId>
       <artifactId>gmetric4j</artifactId>
-      <version>1.0.2</version>
+      <version>${gmetric4j.version}</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>info.ganglia.gmetric4j</groupId>
       <artifactId>gmetric4j</artifactId>
-      <version>1.0.2</version>
+      <version>${gmetric4j.version}</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
@@ -56,7 +60,7 @@
     <dependency>
       <groupId>org.acplt</groupId>
       <artifactId>oncrpc</artifactId>
-      <version>1.0.7</version>
+      <version>${oncrpc.version}</version>
     </dependency>
   </dependencies>
   <parent>
@@ -65,6 +69,12 @@
     <version>7</version>
   </parent>
   <build>
+    <resources>
+        <resource>
+            <directory>src/main/resources</directory>
+            <filtering>true</filtering>
+        </resource>
+    </resources>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -81,7 +91,7 @@
         <version>2.4</version>
         <configuration>
           <archive>
-            <manifestFile>src/main/resources/META-INF/MANIFEST.MF</manifestFile>
+            <manifestFile>target/classes/META-INF/MANIFEST.MF</manifestFile>
           </archive>
         </configuration>
       </plugin>

--- a/src/main/java/info/ganglia/jmxetric/XMLConfigurationService.java
+++ b/src/main/java/info/ganglia/jmxetric/XMLConfigurationService.java
@@ -41,6 +41,7 @@ public class XMLConfigurationService {
         String config = DEFAULT_CONFIG ;
         String wireformat = null ;
         String processName = null ;
+        String spoof = null;
         
         if ( agentArgs != null ) {
             String[] args = agentArgs.split(",");
@@ -50,6 +51,7 @@ public class XMLConfigurationService {
             mode = getTagValue( "mode", args, DEFAULT_MODE );
             wireformat = getTagValue( "wireformat31x", args, "false");
             processName = getTagValue( "process", args, null );
+            spoof = getTagValue( "spoof", args, null );
         }
 
         log.config("Command line argument found: host=" + host );
@@ -57,10 +59,13 @@ public class XMLConfigurationService {
         log.config("Command line args: config=" + config );
         log.config("Command line args: mode=" + mode );
         log.config("Command line args: wireformat31x=" + wireformat );
+        log.config("Command line args: process=" + processName );
+        log.config("Command line args: spoof=" + spoof );
+        
         InputSource inputSource = new InputSource(config);
 
         configureGangliaFromXML( agent, inputSource, host, port, mode, 
-            wireformat);
+            wireformat, spoof );
         configureJMXetricFromXML( agent, inputSource, config, processName );
     }
 
@@ -119,11 +124,13 @@ public class XMLConfigurationService {
      * @param cmdLinePort the port found on the agent arg list
      * @param cmdLineMode the mode found on the agent arg list
      * @param v31x true if the ganglia v31x wire format should be used
+     * @param cmdLineSpoof the spoof value found on the agent arg list
      * @throws java.lang.Exception
      */
     private static void configureGangliaFromXML(JMXetricAgent agent, 
             InputSource inputSource, String cmdLineHost, 
-            String cmdLinePort, String cmdLineMode, String cmdLinev31x) throws Exception {
+            String cmdLinePort, String cmdLineMode, String cmdLinev31x, String cmdLineSpoof)
+                    throws Exception {
         // Gets the config for ganglia
         // Note that the ganglia config needs to be found before the samplers 
         // are created.
@@ -145,14 +152,17 @@ public class XMLConfigurationService {
         String stringv31x = selectParameterFromNode( cmdLinev31x, 
         		g, "wireformat31x", "false");
         boolean v31x = Boolean.parseBoolean(stringv31x) ;
+        String spoof = selectParameterFromNode( cmdLineSpoof, 
+                g, "spoof", null);
         
         StringBuilder buf = new StringBuilder() ;
         buf.append("GMetric host=").append( hostname );
         buf.append(" port=").append( port );
         buf.append(" mode=").append( mode );
         buf.append(" v31x=").append( v31x );
+        buf.append(" spoof=").append( spoof );
         log.fine(buf.toString());
-        GMetric gmetric = new GMetric(hostname, iport, addressingMode, DEFAULT_TTL, v31x );
+        GMetric gmetric = new GMetric(hostname, iport, addressingMode, DEFAULT_TTL, v31x, null, spoof );
         agent.setGmetric(gmetric);
     }
     /**

--- a/src/main/resources/META-INF/MANIFEST.MF
+++ b/src/main/resources/META-INF/MANIFEST.MF
@@ -1,4 +1,4 @@
 Manifest-Version: 1.0
 Premain-Class: info.ganglia.jmxetric.JMXetricAgent
-Boot-Class-Path: oncrpc-1.0.7.jar gmetric4j-1.0.2.jar
+Boot-Class-Path: oncrpc-${oncrpc.version}.jar gmetric4j-${gmetric4j.version}.jar
 Can-Redefine-Classes: false


### PR DESCRIPTION
- Updated to support the "spoof" configuration parameter.
- Updated to version 1.0.3-SNAPSHOT of gmetric4j.
- Updated .gitignore.
- Updated version to 1.0.4-SNAPSHOT.
- Updated the build to pre-process the MANIFEST.MF file to insert the
  proper jar file versions.
