### PR TITLE
Fixes for #11, in combination with ganglia/gmetric4j#11

### DIFF
--- a/src/main/java/info/ganglia/jmxetric/MBeanSampler.java
+++ b/src/main/java/info/ganglia/jmxetric/MBeanSampler.java
@@ -147,7 +147,7 @@ public class MBeanSampler extends GSampler {
                 if (null != value){
                 	Publisher gm = getPublisher();
                 	// log.finer("Announcing metric " + this.toString() + " value=" + value );
-                	gm.publish(process, publishName, value, getType(), getSlope(), getUnits());
+                	gm.publish(process, publishName, value, getType(), getSlope(), getDelay(), getUnits());
                 }
                 
             } catch ( javax.management.InstanceNotFoundException ex ) {

--- a/src/test/java/info/ganglia/jmxetric/MBeanSamplerTest.java
+++ b/src/test/java/info/ganglia/jmxetric/MBeanSamplerTest.java
@@ -35,6 +35,13 @@ public class MBeanSamplerTest {
 			results.put(attributeName, value);
 		}
 		
+		@Override
+		public void publish(String processName, String attributeName,
+				String value, GMetricType type, GMetricSlope slope, int delay,
+				String units) throws GangliaException {
+			results.put(attributeName, value);
+		}
+
 		public String getResult( String attributeName ) {
 			return results.get(attributeName);
 		}


### PR DESCRIPTION
Use the overloaded publish method of GSampler instead, this will allow the delay to be set.
Fixes #11, requires ganglia/gmetric4j#11
