### PR TITLE
Fixed issue #1 wireformat31x=true in config file ignored

### DIFF
--- a/src/main/java/info/ganglia/jmxetric/XMLConfigurationService.java
+++ b/src/main/java/info/ganglia/jmxetric/XMLConfigurationService.java
@@ -49,7 +49,7 @@ public class XMLConfigurationService {
             port = getTagValue( "port", args, null );
             config = getTagValue( "config", args, DEFAULT_CONFIG );
             mode = getTagValue( "mode", args, DEFAULT_MODE );
-            wireformat = getTagValue( "wireformat31x", args, "false");
+            wireformat = getTagValue( "wireformat31x", args, null);
             processName = getTagValue( "process", args, null );
             spoof = getTagValue( "spoof", args, null );
         }


### PR DESCRIPTION
Changed the command line default to none, so that it can honour the xml value if set. 
If none of the values are set the XML default - false will take over.
