### PR TITLE
Fix private MyPublisher class of MBeanSamplerTest

### DIFF
--- a/src/test/java/info/ganglia/jmxetric/MBeanSamplerTest.java
+++ b/src/test/java/info/ganglia/jmxetric/MBeanSamplerTest.java
@@ -38,7 +38,7 @@ public class MBeanSamplerTest {
 		@Override
 		public void publish(String processName, String attributeName,
 				String value, GMetricType type, GMetricSlope slope, int delay,
-				String units) throws GangliaException {
+				int lifetime, String units) throws GangliaException {
 			results.put(attributeName, value);
 		}
 


### PR DESCRIPTION
MyPublisher was not implementing the info.ganglia.gmetric4.Publisher
interface correctly. This commit adds the missing parameter to the method.

Fixes #20
