### PR TITLE
Updates to README, version and installation

### DIFF
--- a/README
+++ b/README
@@ -26,12 +26,12 @@ Installation
     java -javaagent:<path>/jmxetric.jar=host="",port="",config="",process="" usual.java.main.class
 
 Demo / Quickstart
-
+    This example works for version 1.0.6 of jmxetric and gmetric4j.
     1) Ensure you have a gmond running on localhost:8649
         $ pgrep gmond # should return a valid PID
         $ nc localhost 8649 # dumps some XML to stdout
     2) $ git clone https://github.com/ganglia/jmxetric.git
-    3) Download jmxetric-1.0.6.jar, gmetric4j-1.0.6.jar and oncrpc-1.0.7.jar
+    3) Download jmxetric.jar, gmetric4j.jar and oncrpc-1.0.7.jar
        all into the same directory.
     4) $ cd jmxetric
     5) In bash do:


### PR DESCRIPTION
Bump version to 1.0.7.
Add in more details to Demo/Quickstart section.

Should we also make the README a markdown file? This will enable a more friendly README displayed on GitHub - clickable links, formatted syntax, etc. I'm not sure how this may affect other sources that JMXetric is available on, just as maven central repository.
