### PR TITLE
Pattern objectname

### DIFF
--- a/src/main/java/info/ganglia/jmxetric/JMXetricXmlConfigurationService.java
+++ b/src/main/java/info/ganglia/jmxetric/JMXetricXmlConfigurationService.java
@@ -3,10 +3,15 @@ package info.ganglia.jmxetric;
 import info.ganglia.gmetric4j.gmetric.GMetricSlope;
 import info.ganglia.gmetric4j.gmetric.GMetricType;
 
+import java.lang.management.ManagementFactory;
 import java.util.List;
+import java.util.Set;
 import java.util.Vector;
 import java.util.logging.Logger;
 
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
 import javax.xml.xpath.XPathExpressionException;
 
 import org.w3c.dom.Node;
@@ -19,316 +24,334 @@ import org.xml.sax.InputSource;
  * added to the JMXetricAgent.
  */
 public class JMXetricXmlConfigurationService extends XMLConfigurationService {
-	private static Logger log = Logger.getLogger(JMXetricAgent.class.getName());
+  private static Logger log = Logger.getLogger(JMXetricAgent.class.getName());
 
-	/**
-	 * agent that is configured using the XML file
-	 */
-	private JMXetricAgent agent;
+  /**
+   * agent that is configured using the XML file
+   */
+  private JMXetricAgent agent;
 
-	/**
-	 * XML configuration source
-	 */
-	private InputSource inputSource;
+  /**
+   * XML configuration source
+   */
+  private InputSource inputSource;
 
-	/**
-	 * name that is associated with all declared metrics
-	 */
-	private String processName;
+  /**
+   * name that is associated with all declared metrics
+   */
+  private String processName;
 
-	public JMXetricXmlConfigurationService(JMXetricAgent agent,
-			InputSource inputSource, String processName) {
-		this.agent = agent;
-		this.inputSource = inputSource;
-		this.processName = processName;
-	}
+  public JMXetricXmlConfigurationService(JMXetricAgent agent,
+      InputSource inputSource, String processName) {
+    this.agent = agent;
+    this.inputSource = inputSource;
+    this.processName = processName;
+  }
 
-	/**
-	 * Configures {@link info.ganglia.jmxetric.JMXetricAgent} using XML source
-	 * 
-	 * @throws Exception
-	 */
-	void configure() throws Exception {
-		configureProcessName();
-		configureJMXetricAgent();
-	}
+  /**
+   * Configures {@link info.ganglia.jmxetric.JMXetricAgent} using XML source
+   * 
+   * @throws Exception
+   */
+  void configure() throws Exception {
+    configureProcessName();
+    configureJMXetricAgent();
+  }
 
-	/**
-	 * The XML file may specify a processName to be used, which can be different
-	 * from the one used in the constructor. The name in XML takes priority.
-	 * 
-	 * @throws XPathExpressionException
-	 */
-	private void configureProcessName() throws XPathExpressionException {
-		if (processName != null) {
-			return;
-		}
-		processName = "";
-		Node jvm = getXmlNode("/jmxetric-config/jvm", inputSource);
-		if (jvm != null) {
-			processName = jvm.getAttributes().getNamedItem("process")
-					.getNodeValue();
-		}
-	}
+  /**
+   * The XML file may specify a processName to be used, which can be different
+   * from the one used in the constructor. The name in XML takes priority.
+   * 
+   * @throws XPathExpressionException
+   */
+  private void configureProcessName() throws XPathExpressionException {
+    if (processName != null) {
+      return;
+    }
+    processName = "";
+    Node jvm = getXmlNode("/jmxetric-config/jvm", inputSource);
+    if (jvm != null) {
+      processName = jvm.getAttributes().getNamedItem("process").getNodeValue();
+    }
+  }
 
-	/**
-	 * Use the XML source to configure the agent. Source is read for <sample>
-	 * nodes, each node corresponds to a MBeanSampler to be added to the agent.
-	 * 
-	 * @throws XPathExpressionException
-	 * @throws Exception
-	 */
-	private void configureJMXetricAgent() throws XPathExpressionException,
-			Exception {
-		// Gets the config for the samplers
-		NodeList samples = getXmlNodeList("/jmxetric-config/sample",
-				inputSource);
-		for (int i = 0; i < samples.getLength(); i++) {
-			Node sample = samples.item(i);
-			MBeanSampler mbSampler = makeMBeanSampler(sample);
-			agent.addSampler(mbSampler);
-		}
-	}
+  /**
+   * Use the XML source to configure the agent. Source is read for <sample>
+   * nodes, each node corresponds to a MBeanSampler to be added to the agent.
+   * 
+   * @throws XPathExpressionException
+   * @throws Exception
+   */
+  private void configureJMXetricAgent() throws XPathExpressionException,
+      Exception {
+    // Gets the config for the samplers
+    NodeList samples = getXmlNodeList("/jmxetric-config/sample", inputSource);
+    for (int i = 0; i < samples.getLength(); i++) {
+      Node sample = samples.item(i);
+      MBeanSampler mbSampler = makeMBeanSampler(sample);
+      agent.addSampler(mbSampler);
+    }
+  }
 
-	/**
-	 * A <sample> node from the XML source is parsed to make an MBeanSampler.
-	 * 
-	 * @param sample
-	 * @return
-	 * @throws Exception
-	 */
-	private MBeanSampler makeMBeanSampler(Node sample) throws Exception {
-		String delayString = selectParameterFromNode(sample, "delay", "60");
-		int delay = Integer.parseInt(delayString);
+  /**
+   * A <sample> node from the XML source is parsed to make an MBeanSampler.
+   * 
+   * @param sample
+   * @return
+   * @throws Exception
+   */
+  private MBeanSampler makeMBeanSampler(Node sample) throws Exception {
+    String delayString = selectParameterFromNode(sample, "delay", "60");
+    int delay = Integer.parseInt(delayString);
 
-		String initialDelayString = selectParameterFromNode(sample,
-				"initialdelay", "0");
-		int initialDelay = Integer.parseInt(initialDelayString);
+    String initialDelayString = selectParameterFromNode(sample, "initialdelay",
+        "0");
+    int initialDelay = Integer.parseInt(initialDelayString);
 
-		String sampleDMax = selectParameterFromNode(sample, "dmax", "0");
+    String sampleDMax = selectParameterFromNode(sample, "dmax", "0");
 
-		MBeanSampler mBeanSampler = new MBeanSampler(initialDelay, delay,
-				processName);
+    MBeanSampler mBeanSampler = new MBeanSampler(initialDelay, delay,
+        processName);
 
-		NodeList mBeans = getXmlNodeSet("mbean", sample);
-		for (int j = 0; j < mBeans.getLength(); j++) {
-			Node mBean = mBeans.item(j);
-			String mBeanName = selectParameterFromNode(mBean, "name", null);
-			List<MBeanAttribute> attributes = getAttributesForMBean(mBean,
-					sampleDMax);
-			for (MBeanAttribute mBeanAttribute : attributes) {
-				addMBeanAttributeToSampler(mBeanSampler, mBeanName,
-						mBeanAttribute);
-			}
-		}
-		return mBeanSampler;
-	}
+    NodeList mBeans = getXmlNodeSet("mbean", sample);
+    for (int j = 0; j < mBeans.getLength(); j++) {
+      Node mBean = mBeans.item(j);
+      String _mBeanName = selectParameterFromNode(mBean, "name", null);
+      Set<ObjectName> mbeanNames = expandMBeanName(_mBeanName);
+      if (mbeanNames == null) {
+        continue;
+      }
+      for (ObjectName objectName : mbeanNames) {
+        String mBeanName = objectName.getCanonicalName();
 
-	/**
-	 * Adds a MBeanAttribute to an MBeanSampler. This also checks if the
-	 * MBeanAttribute to be added already has a MBeanSampler set, if not it will
-	 * set it.
-	 * 
-	 * @param mBeanSampler
-	 * @param mBeanName
-	 * @param mBeanAttribute
-	 * @throws Exception
-	 */
-	private void addMBeanAttributeToSampler(MBeanSampler mBeanSampler,
-			String mBeanName, MBeanAttribute mBeanAttribute) throws Exception {
-		if (mBeanAttribute.getSampler() == null) {
-			mBeanAttribute.setSampler(mBeanSampler);
-		}
-		mBeanSampler.addMBeanAttribute(mBeanName, mBeanAttribute);
-	}
+        List<MBeanAttribute> attributes = getAttributesForMBean(mBean,
+            sampleDMax);
+        for (MBeanAttribute mBeanAttribute : attributes) {
+          addMBeanAttributeToSampler(mBeanSampler, mBeanName, mBeanAttribute);
+        }
 
-	/**
-	 * Gets a list of MBeanAttributes for a single <mbean>, they correspond to
-	 * the <attribute> tags in the XML file.
-	 * 
-	 * @param mBean
-	 *            the <mbean> node
-	 * @param sampleDMax
-	 *            value of dmax passed down from <sample>
-	 * @return a list of attributes associated to the mbean
-	 * @throws Exception
-	 */
-	List<MBeanAttribute> getAttributesForMBean(Node mBean, String sampleDMax)
-			throws Exception {
-		String mBeanName = selectParameterFromNode(mBean, "name", null);
-		String mBeanPublishName = selectParameterFromNode(mBean, "pname", "");
-		String mBeanDMax = selectParameterFromNode(mBean, "dmax", sampleDMax);
-		log.finer("Mbean is " + mBeanName);
+      }
+    }
+    return mBeanSampler;
+  }
 
-		NodeList attrs = getXmlNodeSet("attribute", mBean);
-		List<MBeanAttribute> attributes = new Vector<MBeanAttribute>();
+  /**
+   * Adds a MBeanAttribute to an MBeanSampler. This also checks if the
+   * MBeanAttribute to be added already has a MBeanSampler set, if not it will
+   * set it.
+   * 
+   * @param mBeanSampler
+   * @param mBeanName
+   * @param mBeanAttribute
+   * @throws Exception
+   */
+  private void addMBeanAttributeToSampler(MBeanSampler mBeanSampler,
+      String mBeanName, MBeanAttribute mBeanAttribute) throws Exception {
+    if (mBeanAttribute.getSampler() == null) {
+      mBeanAttribute.setSampler(mBeanSampler);
+    }
+    mBeanSampler.addMBeanAttribute(mBeanName, mBeanAttribute);
+  }
 
-		for (int i = 0; i < attrs.getLength(); i++) {
-			Node attr = attrs.item(i);
-			if (isComposite(attr)) {
-				attributes.addAll(makeCompositeAttributes(attr, mBeanName,
-						mBeanPublishName, mBeanDMax));
-			} else {
-				attributes.add(makeSimpleAttribute(attr, mBeanName,
-						mBeanPublishName, mBeanDMax));
-			}
-		}
-		return attributes;
-	}
+  /**
+   * Gets a list of MBeanAttributes for a single <mbean>, they correspond to the
+   * <attribute> tags in the XML file.
+   * 
+   * @param mBean
+   *          the <mbean> node
+   * @param sampleDMax
+   *          value of dmax passed down from <sample>
+   * @return a list of attributes associated to the mbean
+   * @throws Exception
+   */
+  List<MBeanAttribute> getAttributesForMBean(Node mBean, String sampleDMax)
+      throws Exception {
+    String mBeanName = selectParameterFromNode(mBean, "name", null);
+    String mBeanPublishName = selectParameterFromNode(mBean, "pname", "");
+    String mBeanDMax = selectParameterFromNode(mBean, "dmax", sampleDMax);
+    log.finer("Mbean is " + mBeanName);
 
-	/**
-	 * Checks if the node is an attribute containing composites
-	 * 
-	 * @param node
-	 * @return true if the node is an attribute containing composites
-	 */
-	private boolean isComposite(Node node) {
-		return node.getNodeName().equals("attribute")
-				&& node.getChildNodes().getLength() > 0;
-	}
+    NodeList attrs = getXmlNodeSet("attribute", mBean);
+    List<MBeanAttribute> attributes = new Vector<MBeanAttribute>();
 
-	/**
-	 * Makes a {@link MBeanAttribute} that corresponds to a simple <attribute>
-	 * tag.
-	 * 
-	 * @param attr
-	 *            the <attribute> node
-	 * @param mBeanName
-	 *            name of the parent mbean
-	 * @param mBeanPublishName
-	 *            publish name of the parent mbean
-	 * @param mBeanDMax
-	 *            value of dmax specified by parent mbean
-	 * @return
-	 */
-	private MBeanAttribute makeSimpleAttribute(Node attr, String mBeanName,
-			String mBeanPublishName, String mBeanDMax) {
-		MBeanAttribute mba = makeMBeanSimpleAttribute(attr, mBeanName,
-				mBeanPublishName, mBeanDMax);
-		return mba;
-	}
+    for (int i = 0; i < attrs.getLength(); i++) {
+      Node attr = attrs.item(i);
+      if (isComposite(attr)) {
+        attributes.addAll(makeCompositeAttributes(attr, mBeanName,
+            mBeanPublishName, mBeanDMax));
+      } else {
+        attributes.add(makeSimpleAttribute(attr, mBeanName, mBeanPublishName,
+            mBeanDMax));
+      }
+    }
+    return attributes;
+  }
 
-	/**
-	 * Makes a list of {@link MBeanAttribute} that corresponds to an <attribute>
-	 * node that contains multiple <composite> nodes.
-	 * 
-	 * @param attr
-	 *            the <attribute> node
-	 * @param mBeanName
-	 *            name of the parent mbean
-	 * @param mBeanPublishName
-	 *            publish name of the parent mbean
-	 * @param mBeanDMax
-	 *            value of dmax specified by parent mbean
-	 * @return list of {@link MBeanAttribute}, one for each <composite>
-	 * @throws XPathExpressionException
-	 */
-	private List<MBeanAttribute> makeCompositeAttributes(Node attr,
-			String mBeanName, String mBeanPublishName, String mBeanDMax)
-			throws XPathExpressionException {
-		List<MBeanAttribute> mbas = new Vector<MBeanAttribute>();
-		MBeanAttribute mba = null;
-		NodeList composites = getXmlNodeSet("composite", attr);
-		String name = selectParameterFromNode(attr, "name", "NULL");
-		for (int l = 0; l < composites.getLength(); l++) {
-			Node composite = composites.item(l);
-			mba = makeMBeanCompositeAttribute(composite, mBeanName,
-					mBeanPublishName, mBeanDMax, name);
-			log.finer("Attr is " + name);
-			mbas.add(mba);
-		}
-		return mbas;
-	}
+  /**
+   * Checks if the node is an attribute containing composites
+   * 
+   * @param node
+   * @return true if the node is an attribute containing composites
+   */
+  private boolean isComposite(Node node) {
+    return node.getNodeName().equals("attribute")
+        && node.getChildNodes().getLength() > 0;
+  }
 
-	private MBeanAttribute makeMBeanSimpleAttribute(Node attr,
-			String mBeanName, String mBeanPublishName, String mBeanDMax) {
-		return makeMBeanAttribute(attr, mBeanName, mBeanPublishName, mBeanDMax,
-				null);
-	}
+  /**
+   * Makes a {@link MBeanAttribute} that corresponds to a simple <attribute>
+   * tag.
+   * 
+   * @param attr
+   *          the <attribute> node
+   * @param mBeanName
+   *          name of the parent mbean
+   * @param mBeanPublishName
+   *          publish name of the parent mbean
+   * @param mBeanDMax
+   *          value of dmax specified by parent mbean
+   * @return
+   */
+  private MBeanAttribute makeSimpleAttribute(Node attr, String mBeanName,
+      String mBeanPublishName, String mBeanDMax) {
+    MBeanAttribute mba = makeMBeanSimpleAttribute(attr, mBeanName,
+        mBeanPublishName, mBeanDMax);
+    return mba;
+  }
 
-	private MBeanAttribute makeMBeanCompositeAttribute(Node composite,
-			String mBeanName, String mBeanPublishName, String mBeanDMax,
-			String attrName) {
-		return makeMBeanAttribute(composite, mBeanName, mBeanPublishName,
-				mBeanDMax, attrName);
-	}
+  /**
+   * Makes a list of {@link MBeanAttribute} that corresponds to an <attribute>
+   * node that contains multiple <composite> nodes.
+   * 
+   * @param attr
+   *          the <attribute> node
+   * @param mBeanName
+   *          name of the parent mbean
+   * @param mBeanPublishName
+   *          publish name of the parent mbean
+   * @param mBeanDMax
+   *          value of dmax specified by parent mbean
+   * @return list of {@link MBeanAttribute}, one for each <composite>
+   * @throws XPathExpressionException
+   */
+  private List<MBeanAttribute> makeCompositeAttributes(Node attr,
+      String mBeanName, String mBeanPublishName, String mBeanDMax)
+      throws XPathExpressionException {
+    List<MBeanAttribute> mbas = new Vector<MBeanAttribute>();
+    MBeanAttribute mba = null;
+    NodeList composites = getXmlNodeSet("composite", attr);
+    String name = selectParameterFromNode(attr, "name", "NULL");
+    for (int l = 0; l < composites.getLength(); l++) {
+      Node composite = composites.item(l);
+      mba = makeMBeanCompositeAttribute(composite, mBeanName, mBeanPublishName,
+          mBeanDMax, name);
+      log.finer("Attr is " + name);
+      mbas.add(mba);
+    }
+    return mbas;
+  }
 
-	private MBeanAttribute makeMBeanAttribute(Node attr, String mBeanName,
-			String mBeanPublishName, String mBeanDMax, String attrName) {
-		String name = selectParameterFromNode(attr, "name", "NULL");
-		String units = selectParameterFromNode(attr, "units", "");
-		String pname = selectParameterFromNode(attr, "pname", "");
-		String slope = selectParameterFromNode(attr, "slope", "");
-		String dMax = selectParameterFromNode(attr, "dmax", mBeanDMax);
-		String type = selectParameterFromNode(attr, "type", "");
-		GMetricType gType = GMetricType.valueOf(type.toUpperCase());
-		GMetricSlope gSlope = GMetricSlope.valueOf(slope.toUpperCase());
-		int dMaxInt = parseDMax(dMax);
-		String metricName = buildMetricName(processName, mBeanName,
-				mBeanPublishName, name, pname);
+  private MBeanAttribute makeMBeanSimpleAttribute(Node attr, String mBeanName,
+      String mBeanPublishName, String mBeanDMax) {
+    return makeMBeanAttribute(attr, mBeanName, mBeanPublishName, mBeanDMax,
+        null);
+  }
 
-		if (attrName == null) {
-			return new MBeanAttribute(processName, name, null, gType, units,
-					gSlope, metricName, dMaxInt);
-		} else {
-			return new MBeanAttribute(processName, attrName, name, gType,
-					units, gSlope, metricName, dMaxInt);
-		}
-	}
+  private MBeanAttribute makeMBeanCompositeAttribute(Node composite,
+      String mBeanName, String mBeanPublishName, String mBeanDMax,
+      String attrName) {
+    return makeMBeanAttribute(composite, mBeanName, mBeanPublishName,
+        mBeanDMax, attrName);
+  }
 
-	/**
-	 * Parses dMaxString, which is the value of dmax read in from a
-	 * configuration file.
-	 * 
-	 * @param dMaxString
-	 *            value read in from configuration
-	 * @return int value of dMaxString if parse is successful, 0 (default value)
-	 *         otherwise
-	 */
-	private int parseDMax(String dMaxString) {
-		int dMax;
-		try {
-			dMax = Integer.parseInt(dMaxString);
-		} catch (NumberFormatException e) {
-			dMax = 0;
-		}
-		return dMax;
-	}
+  private MBeanAttribute makeMBeanAttribute(Node attr, String mBeanName,
+      String mBeanPublishName, String mBeanDMax, String attrName) {
+    String name = selectParameterFromNode(attr, "name", "NULL");
+    String units = selectParameterFromNode(attr, "units", "");
+    String pname = selectParameterFromNode(attr, "pname", "");
+    String slope = selectParameterFromNode(attr, "slope", "");
+    String dMax = selectParameterFromNode(attr, "dmax", mBeanDMax);
+    String type = selectParameterFromNode(attr, "type", "");
+    GMetricType gType = GMetricType.valueOf(type.toUpperCase());
+    GMetricSlope gSlope = GMetricSlope.valueOf(slope.toUpperCase());
+    int dMaxInt = parseDMax(dMax);
+    String metricName = buildMetricName(processName, mBeanName,
+        mBeanPublishName, name, pname);
 
-	/**
-	 * Builds the metric name in ganglia
-	 * 
-	 * @param process
-	 *            the process name, or null if not used
-	 * @param mbeanName
-	 *            the mbean name
-	 * @param mbeanPublishName
-	 *            the mbean publish name, or null if not used
-	 * @param attribute
-	 *            the mbean attribute name
-	 * @param attrPublishName
-	 *            the mbean attribute publish name
-	 * @return the metric name
-	 */
-	private String buildMetricName(String process, String mbeanName,
-			String mbeanPublishName, String attribute, String attrPublishName) {
-		StringBuilder buf = new StringBuilder();
-		if (process != null) {
-			buf.append(process);
-			buf.append("_");
-		}
-		if (mbeanPublishName != null) {
-			buf.append(mbeanPublishName);
-		} else {
-			buf.append(mbeanName);
-		}
-		buf.append("_");
-		if (!"".equals(attrPublishName)) {
-			buf.append(attrPublishName);
-		} else {
-			buf.append(attribute);
-		}
-		return buf.toString();
-	}
+    if (attrName == null) {
+      return new MBeanAttribute(processName, name, null, gType, units, gSlope,
+          metricName, dMaxInt);
+    } else {
+      return new MBeanAttribute(processName, attrName, name, gType, units,
+          gSlope, metricName, dMaxInt);
+    }
+  }
+
+  /**
+   * Parses dMaxString, which is the value of dmax read in from a configuration
+   * file.
+   * 
+   * @param dMaxString
+   *          value read in from configuration
+   * @return int value of dMaxString if parse is successful, 0 (default value)
+   *         otherwise
+   */
+  private int parseDMax(String dMaxString) {
+    int dMax;
+    try {
+      dMax = Integer.parseInt(dMaxString);
+    } catch (NumberFormatException e) {
+      dMax = 0;
+    }
+    return dMax;
+  }
+
+  /**
+   * Builds the metric name in ganglia
+   * 
+   * @param process
+   *          the process name, or null if not used
+   * @param mbeanName
+   *          the mbean name
+   * @param mbeanPublishName
+   *          the mbean publish name, or null if not used
+   * @param attribute
+   *          the mbean attribute name
+   * @param attrPublishName
+   *          the mbean attribute publish name
+   * @return the metric name
+   */
+  private String buildMetricName(String process, String mbeanName,
+      String mbeanPublishName, String attribute, String attrPublishName) {
+    StringBuilder buf = new StringBuilder();
+    if (process != null) {
+      buf.append(process);
+      buf.append("_");
+    }
+    if (mbeanPublishName != null) {
+      buf.append(mbeanPublishName);
+    } else {
+      buf.append(mbeanName);
+    }
+    buf.append("_");
+    if (!"".equals(attrPublishName)) {
+      buf.append(attrPublishName);
+    } else {
+      buf.append(attribute);
+    }
+    return buf.toString();
+  }
+
+  private static Set<ObjectName> expandMBeanName(String mbeanName) {
+    MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+    try {
+      Set<ObjectName> names = mbs.queryNames(new ObjectName(mbeanName), null);
+      System.out.println(names.size());
+      return names;
+    } catch (MalformedObjectNameException e) {
+      log.info("MBean name given in XML is malformed: " + mbeanName);
+    }
+    return null;
+  }
 
 }

--- a/src/main/java/info/ganglia/jmxetric/XMLConfigurationService.java
+++ b/src/main/java/info/ganglia/jmxetric/XMLConfigurationService.java
@@ -18,77 +18,77 @@ import org.xml.sax.InputSource;
  */
 public class XMLConfigurationService {
 
-	private final static XPath xpath = XPathFactory.newInstance().newXPath();
+  private final static XPath xpath = XPathFactory.newInstance().newXPath();
 
-	/**
-	 * Configures the JMXetricAgent based on the supplied agentArgs Command line
-	 * arguments overwrites XML arguments. Any arguments that is required but no
-	 * supplied will be defaulted.
-	 * 
-	 * @param agent
-	 *            the agent to configure
-	 * @param agentArgs
-	 *            the agent arguments list
-	 * @throws java.lang.Exception
-	 */
-	public static void configure(JMXetricAgent agent, String agentArgs)
-			throws Exception {
-		CommandLineArgs args = new CommandLineArgs(agentArgs);
-		InputSource inputSource = new InputSource(args.getConfig());
+  /**
+   * Configures the JMXetricAgent based on the supplied agentArgs Command line
+   * arguments overwrites XML arguments. Any arguments that is required but no
+   * supplied will be defaulted.
+   * 
+   * @param agent
+   *          the agent to configure
+   * @param agentArgs
+   *          the agent arguments list
+   * @throws java.lang.Exception
+   */
+  public static void configure(JMXetricAgent agent, String agentArgs)
+      throws Exception {
+    CommandLineArgs args = new CommandLineArgs(agentArgs);
+    InputSource inputSource = new InputSource(args.getConfig());
 
-		configureGanglia(agent, inputSource, args);
+    configureGanglia(agent, inputSource, args);
 
-		configureJMXetric(agent, inputSource, args);
-	}
+    configureJMXetric(agent, inputSource, args);
+  }
 
-	private static void configureGanglia(JMXetricAgent agent,
-			InputSource inputSource, CommandLineArgs args) throws IOException,
-			XPathExpressionException {
-		GangliaXmlConfigurationService gangliaConfigService = new GangliaXmlConfigurationService(
-				inputSource, args);
-		GMetric gmetric = gangliaConfigService.getConfig();
-		agent.setGmetric(gmetric);
-	}
+  private static void configureGanglia(JMXetricAgent agent,
+      InputSource inputSource, CommandLineArgs args) throws IOException,
+      XPathExpressionException {
+    GangliaXmlConfigurationService gangliaConfigService = new GangliaXmlConfigurationService(
+        inputSource, args);
+    GMetric gmetric = gangliaConfigService.getConfig();
+    agent.setGmetric(gmetric);
+  }
 
-	private static void configureJMXetric(JMXetricAgent agent,
-			InputSource inputSource, CommandLineArgs args) throws Exception {
-		JMXetricXmlConfigurationService jmxetricConfigService = new JMXetricXmlConfigurationService(
-				agent, inputSource, args.getProcessName());
-		jmxetricConfigService.configure();
-	}
+  private static void configureJMXetric(JMXetricAgent agent,
+      InputSource inputSource, CommandLineArgs args) throws Exception {
+    JMXetricXmlConfigurationService jmxetricConfigService = new JMXetricXmlConfigurationService(
+        agent, inputSource, args.getProcessName());
+    jmxetricConfigService.configure();
+  }
 
-	String selectParameterFromNode(Node ganglia, String attributeName,
-			String defaultValue) {
-		if (ganglia == null) {
-			return defaultValue;
-		}
-		Node node = ganglia.getAttributes().getNamedItem(attributeName);
-		if (node == null) {
-			return defaultValue;
-		}
-		String value = node.getNodeValue();
-		if (value == null) {
-			return defaultValue;
-		}
-		return value;
-	}
+  String selectParameterFromNode(Node ganglia, String attributeName,
+      String defaultValue) {
+    if (ganglia == null) {
+      return defaultValue;
+    }
+    Node node = ganglia.getAttributes().getNamedItem(attributeName);
+    if (node == null) {
+      return defaultValue;
+    }
+    String value = node.getNodeValue();
+    if (value == null) {
+      return defaultValue;
+    }
+    return value;
+  }
 
-	protected static Node getXmlNode(String expr, InputSource inputSource)
-			throws XPathExpressionException {
-		return (Node) xpath.evaluate(expr, inputSource, XPathConstants.NODE);
-	}
+  protected static Node getXmlNode(String expr, InputSource inputSource)
+      throws XPathExpressionException {
+    return (Node) xpath.evaluate(expr, inputSource, XPathConstants.NODE);
+  }
 
-	NodeList getXmlNodeList(String expression, InputSource inputSource)
-			throws XPathExpressionException {
-		NodeList samples = (NodeList) xpath.evaluate(expression, inputSource,
-				XPathConstants.NODESET);
-		return samples;
-	}
+  NodeList getXmlNodeList(String expression, InputSource inputSource)
+      throws XPathExpressionException {
+    NodeList samples = (NodeList) xpath.evaluate(expression, inputSource,
+        XPathConstants.NODESET);
+    return samples;
+  }
 
-	NodeList getXmlNodeSet(String expression, Node node)
-			throws XPathExpressionException {
-		NodeList samples = (NodeList) xpath.evaluate(expression, node,
-				XPathConstants.NODESET);
-		return samples;
-	}
+  NodeList getXmlNodeSet(String expression, Node node)
+      throws XPathExpressionException {
+    NodeList samples = (NodeList) xpath.evaluate(expression, node,
+        XPathConstants.NODESET);
+    return samples;
+  }
 }

--- a/src/test/java/info/ganglia/jmxetric/JMXetricXmlConfigurationServiceTest.java
+++ b/src/test/java/info/ganglia/jmxetric/JMXetricXmlConfigurationServiceTest.java
@@ -1,6 +1,6 @@
 package info.ganglia.jmxetric;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 import info.ganglia.gmetric4j.gmetric.GMetricType;
 
 import java.util.List;
@@ -17,100 +17,101 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 
 public class JMXetricXmlConfigurationServiceTest {
-	private JMXetricXmlConfigurationService jmxetric;
-	private InputSource inputSource = new InputSource(
-			"src/test/resources/jmxetric_test.xml");
-	private XPath xpath = XPathFactory.newInstance().newXPath();
-	@Before
-	public void setUp() {
-		jmxetric = new JMXetricXmlConfigurationService(null, inputSource,
-				"TestProcessName");
-	}
+  private JMXetricXmlConfigurationService jmxetric;
+  private InputSource inputSource = new InputSource(
+      "src/test/resources/jmxetric_test.xml");
+  private XPath xpath = XPathFactory.newInstance().newXPath();
 
-	@Test
-	public void testAll() throws XPathExpressionException {
-		NodeList samples = (NodeList) xpath.evaluate("/jmxetric-config/sample",
-				inputSource, XPathConstants.NODESET);
-		Node firstSample = samples.item(0);
-		Node secondSample = samples.item(1);
+  @Before
+  public void setUp() {
+    jmxetric = new JMXetricXmlConfigurationService(null, inputSource,
+        "TestProcessName");
+  }
 
-		NodeList firstMBeans = (NodeList) xpath.evaluate("mbean", firstSample,
-				XPathConstants.NODESET);
-		NodeList secondMBeans = (NodeList) xpath.evaluate("mbean",
-				secondSample, XPathConstants.NODESET);
+  @Test
+  public void testAll() throws XPathExpressionException {
+    NodeList samples = (NodeList) xpath.evaluate("/jmxetric-config/sample",
+        inputSource, XPathConstants.NODESET);
+    Node firstSample = samples.item(0);
+    Node secondSample = samples.item(1);
 
-		Node mBeanWithCompositeAttributes = firstMBeans.item(0);
-		Node mBeanWithSimpleAttributes = secondMBeans.item(1);
-		Node mBeanWithBoth = secondMBeans.item(0);
+    NodeList firstMBeans = (NodeList) xpath.evaluate("mbean", firstSample,
+        XPathConstants.NODESET);
+    NodeList secondMBeans = (NodeList) xpath.evaluate("mbean", secondSample,
+        XPathConstants.NODESET);
 
-		try {
-			testMBeanWithSimpleAttributes(mBeanWithSimpleAttributes);
-			testMBeanWithCompositeAttributes(mBeanWithCompositeAttributes);
-			testMBeanWithBothKinds(mBeanWithBoth);
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
-	}
+    Node mBeanWithCompositeAttributes = firstMBeans.item(0);
+    Node mBeanWithSimpleAttributes = secondMBeans.item(1);
+    Node mBeanWithBoth = secondMBeans.item(0);
 
-	private void testMBeanWithBothKinds(Node mBeanWithBoth) throws Exception {
-		List<MBeanAttribute> attributes = jmxetric.getAttributesForMBean(
-				mBeanWithBoth, "1");
+    try {
+      testMBeanWithSimpleAttributes(mBeanWithSimpleAttributes);
+      testMBeanWithCompositeAttributes(mBeanWithCompositeAttributes);
+      testMBeanWithBothKinds(mBeanWithBoth);
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
 
-		assertEquals(9, attributes.size());
-		assertAttribute(attributes.get(0), "Int", "Int.null", 0,
-				GMetricType.INT32, "");
-		assertAttribute(attributes.get(1), "Long", "Long.null", 0,
-				GMetricType.INT32, "");
-		assertAttribute(attributes.get(6), "Composite", "Composite.date", 0,
-				GMetricType.STRING, "bytes");
-		assertAttribute(attributes.get(7), "Composite", "Composite.integer", 4,
-				GMetricType.INT32, "bytes");
-		assertAttribute(attributes.get(8), "Composite", "Composite.name", 0,
-				GMetricType.INT32, "bytes");
+  private void testMBeanWithBothKinds(Node mBeanWithBoth) throws Exception {
+    List<MBeanAttribute> attributes = jmxetric.getAttributesForMBean(
+        mBeanWithBoth, "1");
 
-	}
+    assertEquals(9, attributes.size());
+    assertAttribute(attributes.get(0), "Int", "Int.null", 0, GMetricType.INT32,
+        "");
+    assertAttribute(attributes.get(1), "Long", "Long.null", 0,
+        GMetricType.INT32, "");
+    assertAttribute(attributes.get(6), "Composite", "Composite.date", 0,
+        GMetricType.STRING, "bytes");
+    assertAttribute(attributes.get(7), "Composite", "Composite.integer", 4,
+        GMetricType.INT32, "bytes");
+    assertAttribute(attributes.get(8), "Composite", "Composite.name", 0,
+        GMetricType.INT32, "bytes");
 
-	private void assertAttribute(MBeanAttribute mBeanAttribute, String name,
-			String canonicalName, int dMax, GMetricType type, String units) {
-		assertEquals(name, mBeanAttribute.getAttributeName());
-		assertEquals(canonicalName, mBeanAttribute.getCanonicalName());
-		assertEquals(dMax, mBeanAttribute.getDMax());
-		assertEquals(type, mBeanAttribute.getType());
-		assertEquals(units, mBeanAttribute.getUnits());
-	}
+  }
 
-	private void testMBeanWithSimpleAttributes(Node mBeanWithSimpleAttributes)
-			throws XPathExpressionException, Exception {
-		List<MBeanAttribute> mbas = jmxetric.getAttributesForMBean(
-				mBeanWithSimpleAttributes, "");
+  private void assertAttribute(MBeanAttribute mBeanAttribute, String name,
+      String canonicalName, int dMax, GMetricType type, String units) {
+    assertEquals(name, mBeanAttribute.getAttributeName());
+    assertEquals(canonicalName, mBeanAttribute.getCanonicalName());
+    assertEquals(dMax, mBeanAttribute.getDMax());
+    assertEquals(type, mBeanAttribute.getType());
+    assertEquals(units, mBeanAttribute.getUnits());
+  }
 
-		assertEquals(2, mbas.size());
-		assertAttribute(mbas.get(0), "ThreadCount", "ThreadCount.null", 0,
-				GMetricType.INT16, "");
-		assertAttribute(mbas.get(1), "DaemonThreadCount",
-				"DaemonThreadCount.null", 0, GMetricType.INT16, "");
-	}
+  private void testMBeanWithSimpleAttributes(Node mBeanWithSimpleAttributes)
+      throws XPathExpressionException, Exception {
+    List<MBeanAttribute> mbas = jmxetric.getAttributesForMBean(
+        mBeanWithSimpleAttributes, "");
 
-	private void testMBeanWithCompositeAttributes(
-			Node mBeanWithCompositeAttributes) throws XPathExpressionException,
-			Exception {
-		List<MBeanAttribute> mbas = jmxetric.getAttributesForMBean(
-				mBeanWithCompositeAttributes, "");
-		assertEquals(8, mbas.size());
+    assertEquals(2, mbas.size());
+    assertAttribute(mbas.get(0), "ThreadCount", "ThreadCount.null", 0,
+        GMetricType.INT16, "");
+    assertAttribute(mbas.get(1), "DaemonThreadCount", "DaemonThreadCount.null",
+        0, GMetricType.INT16, "");
+  }
 
-		assertAttribute(mbas.get(0), "HeapMemoryUsage", "HeapMemoryUsage.init",
-				0, GMetricType.INT32, "bytes");
+  private void testMBeanWithCompositeAttributes(
+      Node mBeanWithCompositeAttributes) throws XPathExpressionException,
+      Exception {
+    List<MBeanAttribute> mbas = jmxetric.getAttributesForMBean(
+        mBeanWithCompositeAttributes, "");
+    assertEquals(8, mbas.size());
 
-		assertAttribute(mbas.get(0), "HeapMemoryUsage", "HeapMemoryUsage.init",
-				0, GMetricType.INT32, "bytes");
+    assertAttribute(mbas.get(0), "HeapMemoryUsage", "HeapMemoryUsage.init", 0,
+        GMetricType.INT32, "bytes");
 
-		assertAttribute(mbas.get(1), "HeapMemoryUsage",
-				"HeapMemoryUsage.committed", 0, GMetricType.INT32, "bytes");
+    assertAttribute(mbas.get(0), "HeapMemoryUsage", "HeapMemoryUsage.init", 0,
+        GMetricType.INT32, "bytes");
 
-		assertAttribute(mbas.get(2), "HeapMemoryUsage", "HeapMemoryUsage.used",
-				0, GMetricType.INT32, "bytes");
+    assertAttribute(mbas.get(1), "HeapMemoryUsage",
+        "HeapMemoryUsage.committed", 0, GMetricType.INT32, "bytes");
 
-		assertAttribute(mbas.get(3), "HeapMemoryUsage", "HeapMemoryUsage.max",
-				0, GMetricType.INT32, "bytes");
-	}
+    assertAttribute(mbas.get(2), "HeapMemoryUsage", "HeapMemoryUsage.used", 0,
+        GMetricType.INT32, "bytes");
+
+    assertAttribute(mbas.get(3), "HeapMemoryUsage", "HeapMemoryUsage.max", 0,
+        GMetricType.INT32, "bytes");
+  }
 }

--- a/src/test/java/info/ganglia/jmxetric/JMXetricXmlConfigurationServiceTest.java
+++ b/src/test/java/info/ganglia/jmxetric/JMXetricXmlConfigurationServiceTest.java
@@ -54,7 +54,7 @@ public class JMXetricXmlConfigurationServiceTest {
   }
 
   private void testMBeanWithBothKinds(Node mBeanWithBoth) throws Exception {
-    List<MBeanAttribute> attributes = jmxetric.getAttributesForMBean(
+    List<MBeanAttribute> attributes = jmxetric.getAttributesForMBean("",
         mBeanWithBoth, "1");
 
     assertEquals(9, attributes.size());
@@ -82,7 +82,7 @@ public class JMXetricXmlConfigurationServiceTest {
 
   private void testMBeanWithSimpleAttributes(Node mBeanWithSimpleAttributes)
       throws XPathExpressionException, Exception {
-    List<MBeanAttribute> mbas = jmxetric.getAttributesForMBean(
+    List<MBeanAttribute> mbas = jmxetric.getAttributesForMBean("",
         mBeanWithSimpleAttributes, "");
 
     assertEquals(2, mbas.size());
@@ -95,7 +95,7 @@ public class JMXetricXmlConfigurationServiceTest {
   private void testMBeanWithCompositeAttributes(
       Node mBeanWithCompositeAttributes) throws XPathExpressionException,
       Exception {
-    List<MBeanAttribute> mbas = jmxetric.getAttributesForMBean(
+    List<MBeanAttribute> mbas = jmxetric.getAttributesForMBean("",
         mBeanWithCompositeAttributes, "");
     assertEquals(8, mbas.size());
 
@@ -113,5 +113,17 @@ public class JMXetricXmlConfigurationServiceTest {
 
     assertAttribute(mbas.get(3), "HeapMemoryUsage", "HeapMemoryUsage.max", 0,
         GMetricType.INT32, "bytes");
+  }
+
+  @Test
+  public void testBuildPName() {
+    assertEquals("pname_b",
+        JMXetricXmlConfigurationService.buildPname("a.b.c", "a.*.c", "pname_"));
+    assertEquals("pname_b.c",
+        JMXetricXmlConfigurationService.buildPname("a.b.c", "a.*", "pname_"));
+    assertEquals("pname_b.c", JMXetricXmlConfigurationService.buildPname(
+        "a.b.c.d", "a.*.d", "pname_"));
+    assertEquals("pname_",
+        JMXetricXmlConfigurationService.buildPname("a.b.c", "a.b.c", "pname_"));
   }
 }

--- a/src/test/java/info/ganglia/jmxetric/MBeanSamplerTest.java
+++ b/src/test/java/info/ganglia/jmxetric/MBeanSamplerTest.java
@@ -1,12 +1,11 @@
 package info.ganglia.jmxetric;
 
-import static org.junit.Assert.*;
-
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import info.ganglia.gmetric4j.Publisher;
 import info.ganglia.gmetric4j.gmetric.GMetricSlope;
 import info.ganglia.gmetric4j.gmetric.GMetricType;
 import info.ganglia.gmetric4j.gmetric.GangliaException;
-import info.ganglia.jmxetric.MBeanSampler;
 
 import java.lang.management.ManagementFactory;
 import java.util.HashMap;
@@ -24,116 +23,107 @@ import org.junit.Test;
  */
 public class MBeanSamplerTest {
 
-	public static String BEAN_NAME="jmxetric:type=Test.Example";
-	private class MyPublisher implements Publisher 
-	{
-		Map<String, String> results = new HashMap<String,String>();
+  public static String BEAN_NAME = "jmxetric:type=Test.Example";
 
-		public void publish(String processName, String attributeName,
-				String value, GMetricType type, GMetricSlope slope, String units)
-				throws GangliaException {
-			results.put(attributeName, value);
-		}
-		
-		@Override
-		public void publish(String processName, String attributeName,
-				String value, GMetricType type, GMetricSlope slope, int delay,
-				int lifetime, String units) throws GangliaException {
-			results.put(attributeName, value);
-		}
+  private class MyPublisher implements Publisher {
+    Map<String, String> results = new HashMap<String, String>();
 
-		public String getResult( String attributeName ) {
-			return results.get(attributeName);
-		}
-		
-	}
-	@Before
-	public void setUp() throws Exception {
-		MBeanServer mbs = ManagementFactory.getPlatformMBeanServer(); 
-		ObjectName name = new ObjectName(BEAN_NAME); 
-		Example mbean = new Example(); 
-		mbs.registerMBean(mbean, name);
-	}
-	@After
-	public void tearDown() throws Exception {
-		MBeanServer mbs = ManagementFactory.getPlatformMBeanServer(); 
-		ObjectName name = new ObjectName(BEAN_NAME);
-		mbs.unregisterMBean(name);
-	}
-    /**
-     * Test of attribute sample, type Long
-     */
-    @Test
-    public void sampleLong() throws Exception {
-        MBeanSampler sampler = new MBeanSampler(0, 30000, "TEST") ;
-        MyPublisher publisher = new MyPublisher() ;
-        sampler.setPublisher(publisher);
-        sampler.addMBeanAttribute(BEAN_NAME, "Long", GMetricType.INT32, 
-        		"bytes", GMetricSlope.BOTH, "Longer");
-        sampler.run() ;
-        String value = publisher.getResult("Longer");
-        assertEquals( Example.LONG_VALUE, Long.valueOf(value ));
+    @Override
+    public void publish(String processName, String attributeName, String value,
+        GMetricType type, GMetricSlope slope, String units)
+        throws GangliaException {
+      results.put(attributeName, value);
     }
-    /**
-     * Test of attribute sample, type String
-     */
-    @Test
-    public void sampleComposite() throws Exception {
-        MBeanSampler sampler = new MBeanSampler(0, 30000, "TEST") ;
-        MyPublisher publisher = new MyPublisher() ;
-        sampler.setPublisher(publisher);
-        
-        String compNamePublishName = "compName";
-        sampler.addMBeanAttribute(BEAN_NAME, 
-        						"Composite",
-        						"name", 
-        						GMetricType.STRING, 
-        						"bytes", 
-        						GMetricSlope.BOTH, 
-        						compNamePublishName);
-        
-        String compIntPublishName = "compInt";
-        sampler.addMBeanAttribute(BEAN_NAME, 
-        							"Composite",
-        							"integer", 
-        							GMetricType.STRING, 
-        							"bytes", 
-        							GMetricSlope.BOTH, 
-        							compIntPublishName);
-        
-        String compDatePublishName = "compDate";
-        sampler.addMBeanAttribute(BEAN_NAME, 
-									"Composite",
-									"date", 
-									GMetricType.STRING, 
-									"bytes", 
-									GMetricSlope.BOTH, 
-									compDatePublishName);
-        
-        sampler.run();
-        
-        assertEquals( ExampleComposite.STRING_VALUE, 
-        				publisher.getResult(compNamePublishName) );
-        
-        assertEquals( "" + ExampleComposite.INT_VALUE, 
-        				publisher.getResult(compIntPublishName) );
-        
-        assertEquals( "" + ExampleComposite.DATE_VALUE, 
-        				publisher.getResult(compDatePublishName) );
+
+    @Override
+    public void publish(String processName, String attributeName, String value,
+        GMetricType type, GMetricSlope slope, int delay, int lifetime,
+        String units) throws GangliaException {
+      results.put(attributeName, value);
     }
-    /**
-     * Test of attribute sample, type int, slope positive
-     */
-    @Test
-    public void sampleCounter() throws Exception {
-        MBeanSampler sampler = new MBeanSampler(0, 1, "TEST") ;
-        MyPublisher publisher = new MyPublisher() ;
-        sampler.setPublisher(publisher);
-        sampler.addMBeanAttribute(BEAN_NAME, "Counter", GMetricType.INT32,
-        		"units", GMetricSlope.POSITIVE, "counter");
-        sampler.run() ;
-        String value = publisher.getResult("counter");
-        assertTrue( Integer.valueOf(value) >= 0);
+
+    public String getResult(String attributeName) {
+      return results.get(attributeName);
     }
-    
+
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+    ObjectName name = new ObjectName(BEAN_NAME);
+    Example mbean = new Example();
+    mbs.registerMBean(mbean, name);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+    ObjectName name = new ObjectName(BEAN_NAME);
+    mbs.unregisterMBean(name);
+  }
+
+  /**
+   * Test of attribute sample, type Long
+   */
+  @Test
+  public void sampleLong() throws Exception {
+    MBeanSampler sampler = new MBeanSampler(0, 30000, "TEST");
+    MyPublisher publisher = new MyPublisher();
+    sampler.setPublisher(publisher);
+    sampler.addMBeanAttribute(BEAN_NAME, "Long", GMetricType.INT32, "bytes",
+        GMetricSlope.BOTH, "Longer");
+    sampler.run();
+    String value = publisher.getResult("Longer");
+    assertEquals(Example.LONG_VALUE, Long.valueOf(value));
+  }
+
+  /**
+   * Test of attribute sample, type String
+   */
+  @Test
+  public void sampleComposite() throws Exception {
+    MBeanSampler sampler = new MBeanSampler(0, 30000, "TEST");
+    MyPublisher publisher = new MyPublisher();
+    sampler.setPublisher(publisher);
+
+    String compNamePublishName = "compName";
+    sampler.addMBeanAttribute(BEAN_NAME, "Composite", "name",
+        GMetricType.STRING, "bytes", GMetricSlope.BOTH, compNamePublishName);
+
+    String compIntPublishName = "compInt";
+    sampler.addMBeanAttribute(BEAN_NAME, "Composite", "integer",
+        GMetricType.STRING, "bytes", GMetricSlope.BOTH, compIntPublishName);
+
+    String compDatePublishName = "compDate";
+    sampler.addMBeanAttribute(BEAN_NAME, "Composite", "date",
+        GMetricType.STRING, "bytes", GMetricSlope.BOTH, compDatePublishName);
+
+    sampler.run();
+
+    assertEquals(ExampleComposite.STRING_VALUE,
+        publisher.getResult(compNamePublishName));
+
+    assertEquals("" + ExampleComposite.INT_VALUE,
+        publisher.getResult(compIntPublishName));
+
+    assertEquals("" + ExampleComposite.DATE_VALUE,
+        publisher.getResult(compDatePublishName));
+  }
+
+  /**
+   * Test of attribute sample, type int, slope positive
+   */
+  @Test
+  public void sampleCounter() throws Exception {
+    MBeanSampler sampler = new MBeanSampler(0, 1, "TEST");
+    MyPublisher publisher = new MyPublisher();
+    sampler.setPublisher(publisher);
+    sampler.addMBeanAttribute(BEAN_NAME, "Counter", GMetricType.INT32, "units",
+        GMetricSlope.POSITIVE, "counter");
+    sampler.run();
+    String value = publisher.getResult("counter");
+    assertTrue(Integer.valueOf(value) >= 0);
+  }
+
 }

--- a/src/test/resources/jmxetric_test.xml
+++ b/src/test/resources/jmxetric_test.xml
@@ -64,7 +64,12 @@
 			</attribute>
 		</mbean>
 		
-		<mbean name="java.lang:type=Threading" pname="Threading" >
+		<mbean name="*:type=Threading" pname="Threading" >
+			<attribute name="ThreadCount" type="int16" />
+			<attribute name="DaemonThreadCount" type="int16" />
+		</mbean>
+
+		<mbean name="*:*" pname="Threading" >
 			<attribute name="ThreadCount" type="int16" />
 			<attribute name="DaemonThreadCount" type="int16" />
 		</mbean>


### PR DESCRIPTION
Merge the HEAD of ganglia:master into this fix for #3.
Malformed patterns are ignored and valid patterns are expanded into `ObjectName`s and added to the sampler one-by-one.
