### PR TITLE
Allow dynamic reconfiguring in the background.

### DIFF
--- a/README
+++ b/README
@@ -62,7 +62,7 @@ Configuration
                   (so that metrics from different JVMs on the same host can be 
                   determined)
 
-    XML Configuation File
+    XML Configuration File
 
     JMXetric schedules a number of "samples", that queries a list of "mbeans", 
     that have "attributes".  

--- a/src/main/java/info/ganglia/jmxetric/BackgroundConfigurationRefresher.java
+++ b/src/main/java/info/ganglia/jmxetric/BackgroundConfigurationRefresher.java
@@ -68,13 +68,21 @@ public class BackgroundConfigurationRefresher extends XMLConfigurationService {
         File theFile = new File(args.getConfig());
         InputStream is = new FileInputStream(theFile);
 
-        DigestInputStream dis = new DigestInputStream(is, md);
-        while (dis.read() != -1) {
-            // Place holder to read the entire file
-        }
+        try {
+            DigestInputStream dis = new DigestInputStream(is, md);
+            try {
+                while (dis.read() != -1) {
+                    // NOTE: This reads the entire file, that's why the while loop is blank.
+                }
 
-        byte[] digest = md.digest();
-        return new String(digest).hashCode();
+                byte[] digest = md.digest();
+                return new String(digest).hashCode();
+            } finally {
+                dis.close();
+            }
+        } finally {
+            is.close();
+        }
     }
 
     private void startBackgroundThread() {

--- a/src/main/java/info/ganglia/jmxetric/BackgroundConfigurationRefresher.java
+++ b/src/main/java/info/ganglia/jmxetric/BackgroundConfigurationRefresher.java
@@ -1,0 +1,105 @@
+package info.ganglia.jmxetric;
+
+import info.ganglia.gmetric4j.gmetric.GMetric;
+import org.xml.sax.InputSource;
+
+import org.w3c.dom.Node;
+import java.io.*;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Timer;
+import java.util.TimerTask;
+
+
+public class BackgroundConfigurationRefresher extends XMLConfigurationService {
+
+    private JMXetricAgent agent = null;
+    private final InputSource inputSource;
+    private final CommandLineArgs args;
+    private final String agentArgs;
+    private int pollingFrequency;
+    private int lastHash = -1;
+
+    public BackgroundConfigurationRefresher(String agentArgs) {
+        this.agentArgs = agentArgs;
+        this.args = new CommandLineArgs(agentArgs);
+        this.inputSource = new InputSource(args.getConfig());
+    }
+
+    public void initialize() throws Exception {
+        Node root = getXmlNode("/jmxetric-config/refreshconfig", inputSource);
+
+        startNewAgent();
+
+        if (isEnabled(root)) {
+            pollingFrequency = getPollingFrequencySeconds(root);
+            startBackgroundThread();
+        }
+    }
+
+    private void startNewAgent() throws Exception {
+        if (agent != null) {
+            agent.stop();
+            GMetric gmetric = agent.getGmetric();
+            if (gmetric != null) {
+                gmetric.close();
+            }
+            agent = null;
+        }
+
+        agent = new JMXetricAgent();
+        XMLConfigurationService.configure(agent, agentArgs);
+        agent.start();
+        lastHash = getConfigHash();
+    }
+
+    private boolean isEnabled(Node root) {
+        return selectParameterFromNode(root, "enabled", "false").toLowerCase().equals("true");
+    }
+
+    private int getPollingFrequencySeconds(Node root) {
+        return Integer.parseInt(selectParameterFromNode(root, "frequency", "5"));
+    }
+
+    private int getConfigHash() throws NoSuchAlgorithmException, IOException {
+        MessageDigest md = MessageDigest.getInstance("MD5");
+
+        File theFile = new File(args.getConfig());
+        InputStream is = new FileInputStream(theFile);
+
+        DigestInputStream dis = new DigestInputStream(is, md);
+        while (dis.read() != -1) {
+            // Place holder to read the entire file
+        }
+
+        byte[] digest = md.digest();
+        return new String(digest).hashCode();
+    }
+
+    private void startBackgroundThread() {
+        TimerTask task = new TimerTask() {
+            @Override
+            public void run() {
+                try {
+                    int currentHash = getConfigHash();
+                    if (currentHash != lastHash) {
+                        System.out.println("The file has changed.  Initializing a dynamic reload for the instance.");
+                        startNewAgent();
+                    }
+                } catch (FileNotFoundException e) {
+                    System.out.println(String.format("Could not find the config file: %s", args.getConfig()));
+                } catch (NoSuchAlgorithmException e) {
+                    System.out.println("Your system does not contain the MD5 digest algorithm.");
+                } catch (Exception e) {
+                    System.out.println("Unknown exception encountered.");
+                    e.printStackTrace();
+                }
+            }
+        };
+
+        Timer timer = new Timer(true);
+        timer.scheduleAtFixedRate(task, pollingFrequency * 1000, pollingFrequency * 1000);
+    }
+
+}

--- a/src/main/java/info/ganglia/jmxetric/GangliaXmlConfigurationService.java
+++ b/src/main/java/info/ganglia/jmxetric/GangliaXmlConfigurationService.java
@@ -126,9 +126,9 @@ class GangliaXmlConfigurationService extends XMLConfigurationService {
 	/**
 	 * UDPAddressingMode to use for reporting
 	 * 
-	 * @return {@link info.ganglia.gmetric4j.gmetric.UDPAddressingMode.UNICAST}
+	 * @return {@link info.ganglia.gmetric4j.gmetric.GMetric.UDPAddressingMode.UNICAST}
 	 *         or
-	 *         {@link info.ganglia.gmetric4j.gmetric.UDPAddressingMode.MULTICAST}
+	 *         {@link info.ganglia.gmetric4j.gmetric.GMetric.UDPAddressingMode.MULTICAST}
 	 */
 	private UDPAddressingMode getAddressingMode() {
 		String mode = getGangliaConfig(args.getMode(), ganglia, "mode",

--- a/src/main/java/info/ganglia/jmxetric/JMXetricAgent.java
+++ b/src/main/java/info/ganglia/jmxetric/JMXetricAgent.java
@@ -45,11 +45,8 @@ public class JMXetricAgent extends GMonitor {
      */
     public static void premain(String agentArgs, Instrumentation inst) {
         System.out.println(STARTUP_NOTICE) ;
-        JMXetricAgent a = null ;
         try {
-            a = new JMXetricAgent();
-            XMLConfigurationService.configure(a, agentArgs);
-            a.start();
+            new BackgroundConfigurationRefresher(agentArgs).initialize();
         } catch ( Exception ex ) {
             // log.severe("Exception starting JMXetricAgent");
             ex.printStackTrace();

--- a/src/test/java/info/ganglia/jmxetric/JMXetricAgentIT.java
+++ b/src/test/java/info/ganglia/jmxetric/JMXetricAgentIT.java
@@ -4,8 +4,6 @@ import static org.junit.Assert.*;
 
 
 import info.ganglia.gmetric4j.gmetric.GMetricResult;
-import info.ganglia.jmxetric.JMXetricAgent;
-import info.ganglia.jmxetric.XMLConfigurationService;
 
 import java.lang.management.ManagementFactory;
 

--- a/src/test/resources/jmxetric_test.xml
+++ b/src/test/resources/jmxetric_test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="ISO-8859-1" ?>
 <!DOCTYPE jmxetric-config [
-   <!ELEMENT jmxetric-config (sample|ganglia|jvm)*>
+   <!ELEMENT jmxetric-config (sample|ganglia|jvm|refreshconfig)*>
    <!ELEMENT sample (mbean)*>
       <!ATTLIST sample delay CDATA #REQUIRED>
       <!ATTLIST sample initialdelay CDATA "0">
@@ -28,6 +28,9 @@
       <!ATTLIST ganglia port CDATA #REQUIRED>
       <!ATTLIST ganglia mode CDATA #REQUIRED>
       <!ATTLIST ganglia wireformat31x CDATA #REQUIRED>
+   <!ELEMENT refreshconfig EMPTY>
+      <!ATTLIST refreshconfig enabled CDATA #REQUIRED>
+      <!ATTLIST refreshconfig frequency CDATA #REQUIRED>
    <!ELEMENT jvm EMPTY>
       <!ATTLIST jvm process CDATA "">
 ]>
@@ -74,11 +77,12 @@
 			<attribute name="DaemonThreadCount" type="int16" />
 		</mbean>
 
-        <mbean name="java.lang:type=OperatingSystem" pname="OS" >
-            <attribute name="ProcessCpuTime" type="int32" slope="positive"/>
-        </mbean>
+    <mbean name="java.lang:type=OperatingSystem" pname="OS" >
+      <attribute name="ProcessCpuTime" type="int32" slope="positive"/>
+    </mbean>
                              
 	</sample>
 	<ganglia hostname="localhost" port="8649" mode="multicast" wireformat31x="true" />
+	<refreshconfig enabled="true" frequency="15" />
 </jmxetric-config>
 


### PR DESCRIPTION
Testing:
- [x] `mvn test` passed
- [x] Tested in a pseudo-production environment to redirect to a different ganglia-monitor process

I am open to ideas on how to write a regression IT for this.  Instead of testing the IP redirection that I was doing, maybe we could test sending a metric/not sending a metric, since that should trigger as well?
